### PR TITLE
Enable python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ deploy:
   user: tuxtimo
   password:
     secure: eNrDuSAQuR0xVFb+ZfHZ93mZBEKGWNnidSHTM+8DkuA3OKGTD/Gf3TGAVLaqqURtChukopOANvoBqTWSHMXe6mDSiTn6cPpqxa7WBcOkF4yzzSVQ+ch/wjgpabzgi+XfT6tTo7KI8JYwgxg4NivN/Iv6uxzVqmc7hxwrSJbwruav1ddvonGb+I4M1LYcvUWTFEwlCvBxr+a9CdQ0+JHTtgdCF0T/71NwQJKmA7NtDaS6hex7kJY/CADBsowECURraB4jsbbqnw8sKUDsi6M5/aHSrC0KlpPrSxoESy4EFB7x77WVQxLTcTOqnQQ1ZazNc0g9YfZ7TqcH6cXjcAxqmx/rsmE9EDpauml4IySJWYvEyCMkS2LsqWZI4Em8t2MRO96Zoou3FPgabuUmwEpLlBIfLxTW+XDt2M3fa7wtHP4rIA3e6ruSmVitdC6gFG0nMdGIC/o6s/99Qqx/05eNm1BQ5PdFCzKyVg82mZsqyoSV/37qaVic3pDYIYmGpsm1G/pS4UdH9qGcjP8P0n/986EBAenOeExg9a53XoDms6C/mkeMqJHkJ6WrEKDmaFiUHWz2D3mFTdpL+xWnpOP/b/4/2XSQVh86z+5wW0iXb+wxMdmMSv9T8VBb5kDWj6/6D/y0V90k1i8d2pkmJ3sJAqWNBfw2pC5D03J7qH8zPdU=
+  distributions: sdist bdist_wheel
   on:
     tags: true
-    distributions: sdist bdist_wheel
     repo: neolynx/cirrina
     condition: $TRAVIS_PYTHON_VERSION = "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
     - '3.5'
+    - '3.6'
+    - '3.7'
+    - '3.8'
 
 install:
     - python setup.py build sdist
@@ -17,3 +20,4 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: neolynx/cirrina
+    condition: $TRAVIS_PYTHON_VERSION = "3.5"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)',
         'Topic :: Utilities'


### PR DESCRIPTION
Hi @neolynx,

To enable `cirrina` in https://github.com/the-benchmarker/web-frameworks/issues/1638, I need to make it runnable on `python` **3.8**.

This `PR` :
+ [x] Add classifiers to `setup.py` so it could be installable in `python` `>= 3.5`
+ [x] Add `python` `>= 3.5` on CI
+ [x] Fix CI to push on `pypi`

Regards,