### PR TITLE
Allow authenticated handlers to take more than a single parameter

### DIFF
--- a/cirrina/server.py
+++ b/cirrina/server.py
@@ -319,12 +319,12 @@ class Server:
         executing the decorated function.
         """
         @wraps(func)
-        async def _wrapper(request):  # pylint: disable=missing-docstring
+        async def _wrapper(request, *args, **kwargs):  # pylint: disable=missing-docstring
             if request.cirrina.web_session.new:
                 if self.auth_unauthorized_handler:
                     return await self.auth_unauthorized_handler(request)
                 return web.Response(status=401)
-            return await func(request)
+            return await func(request, *args, **kwargs)
         return _wrapper
 
     # HTTP protocol


### PR DESCRIPTION
E.g. handlers dealing with file uploads take more than one parameter, so
applying the "@authenticated" decorator to them would fail.