### PR TITLE
Allow to configure aiohttp access_log_class

### DIFF
--- a/cirrina/server.py
+++ b/cirrina/server.py
@@ -100,6 +100,7 @@ class Server:
         self.http_post(self.logout_url)(self._logout)
 
         self.logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+        self.access_log_class = web.AccessLogger
 
         # swagger documentation
         self.title = "Cirrina based web application"
@@ -137,6 +138,7 @@ class Server:
             self.app.make_handler(
                 access_log_format='%r %s',
                 access_log=self.logger,
+                access_log_class=self.access_log_class,
                 logger=self.logger),
             address,
             port)
@@ -160,12 +162,14 @@ class Server:
         #         await ws.close()
         await self.app.shutdown()
 
-    def run(self, address='127.0.0.1', port=2100, logger=None, debug=False):
+    def run(self, address='127.0.0.1', port=2100, logger=None, debug=False, access_log_class=None):
         """
         Run cirrina server event loop.
         """
         if logger:
             self.logger = logger
+        if access_log_class:
+            self.access_log_class = access_log_class
 
         # set cirrina logger loglevel
         self.logger.setLevel(logging.DEBUG if debug else logging.INFO)

--- a/examples/basic/server_logging.py
+++ b/examples/basic/server_logging.py
@@ -1,0 +1,39 @@
+"""
+`cirrina` - Opinionated web framework
+
+Simple cirrina server example.
+
+:license: LGPL, see LICENSE for details
+"""
+
+import logging
+import sys
+import cirrina
+from aiohttp.abc import AbstractAccessLogger
+
+#: Create cirrina app.
+app = cirrina.Server()
+
+class AccessLogger(AbstractAccessLogger):
+
+    def _get_username(self, request):
+        try:
+            return request.cirrina.web_session.get('username')
+        except Exception:
+            return None
+
+    def log(self, request, response, time):
+        username = self._get_username(request)
+        self.logger.info(
+                f'[{username}] '
+                f'{request.remote} '
+                f'{request.method} {request.path} {response.status} '
+                f'in {time:.6f}s')
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    port = 8765
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    app.run('0.0.0.0', port, debug=True, access_log_class=AccessLogger)


### PR DESCRIPTION
This allows to have user-defined loggers, e.g. to log the logged in user (see example in the patchset).